### PR TITLE
Mongodb

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,10 +35,13 @@ the following steps:
 
 
 - edit tkpweb/settings.py:
-  
+
   - verify that you're happy with the default database settings
 
   - edit the `SECRET_KEY`.
+
+  - if required, enable the MongoDB image store and enter the details of your
+    MongoDB database.
 
 - edit tkpweb/apps/database/views.py:
 
@@ -62,7 +65,7 @@ the following steps:
 
 - Convert the \*scss files in the static directories to css files,
   using sass ::
-  
+
     sass base.scss:base.css
 
 - Collect the static files ::
@@ -99,6 +102,9 @@ Dependencies
 
 - Sass, to convert the scss files to CSS files.
   See http://sass-lang.com/
+
+- (Optionally) PyMongo (including GridFS) to fetch images from a MongoDB
+  databse: https://github.com/mongodb/mongo-python-driver
 
 
 License

--- a/tkpweb/apps/dataset/tools/image.py
+++ b/tkpweb/apps/dataset/tools/image.py
@@ -4,21 +4,32 @@ from tkp.utility.accessors import DataAccessor
 from tkp.utility.accessors import FITSImage
 from tkp.utility.accessors import CASAImage
 
+from tkpweb.settings import MONGODB
+if MONGODB["enabled"]:
+    from .mongo import fetch_hdu_from_mongo
 
 def open_image(url, database=None):
-    def get_file_by_type(url):
-        if not os.path.exists(url):
-            return None
-        name, ext = os.path.splitext(url)
-        if ext.lower() == '.fits':
-            image = FITSImage(url)
-        elif ext.lower() == '.img':
-            image = AIPSppImage(url)
+    def get_file_by_url(url):
+        image = None
+        try:
+            if os.path.isdir(filename):
+                # Likely a CASA image
+                image = accessors.CASAImage(filename)
+            elif os.path.exists(filename):
+                image = accessors.FITSImage(filename)
+            elif MONGODB["enabled"]:
+                hdu = fetch_hdu_from_mongo(filename)
+                image = accessors.FITSImage(hdu)
+            else:
+                raise Exception("FITS file not available")
+        except Exception, e:
+            # Unable to access file
+            print e
         return image
 
     image = None
     if isinstance(url, DataAccessor):
-        pass
+        image = url
     elif isinstance(url, basestring):
         image = get_file_by_type(url)
     elif isinstance(url, (int, long)):
@@ -26,5 +37,5 @@ def open_image(url, database=None):
         url = Image(id=url, database=database).url
         image = get_file_by_type(url)
     else:
-        raise ValueError("unknown image type")
+        raise ValueError("unable to fetch type")
     return image

--- a/tkpweb/apps/dataset/tools/image.py
+++ b/tkpweb/apps/dataset/tools/image.py
@@ -31,11 +31,11 @@ def open_image(url, database=None):
     if isinstance(url, DataAccessor):
         image = url
     elif isinstance(url, basestring):
-        image = get_file_by_type(url)
+        image = get_file_by_url(url)
     elif isinstance(url, (int, long)):
         db = database if database else DataBase()
         url = Image(id=url, database=database).url
-        image = get_file_by_type(url)
+        image = get_file_by_url(url)
     else:
-        raise ValueError("unable to fetch type")
+        raise ValueError("unable to fetch url")
     return image

--- a/tkpweb/apps/dataset/tools/image.py
+++ b/tkpweb/apps/dataset/tools/image.py
@@ -14,12 +14,12 @@ def open_image(url, database=None):
         try:
             if os.path.isdir(url):
                 # Likely a CASA image
-                image = accessors.CASAImage(url)
+                image = CASAImage(url)
             elif os.path.exists(url):
-                image = accessors.FITSImage(url)
+                image = FITSImage(url)
             elif MONGODB["enabled"]:
                 hdu = fetch_hdu_from_mongo(url)
-                image = accessors.FITSImage(hdu)
+                image = FITSImage(hdu)
             else:
                 raise Exception("FITS file not available")
         except Exception, e:

--- a/tkpweb/apps/dataset/tools/image.py
+++ b/tkpweb/apps/dataset/tools/image.py
@@ -12,13 +12,13 @@ def open_image(url, database=None):
     def get_file_by_url(url):
         image = None
         try:
-            if os.path.isdir(filename):
+            if os.path.isdir(url):
                 # Likely a CASA image
-                image = accessors.CASAImage(filename)
-            elif os.path.exists(filename):
-                image = accessors.FITSImage(filename)
+                image = accessors.CASAImage(url)
+            elif os.path.exists(url):
+                image = accessors.FITSImage(url)
             elif MONGODB["enabled"]:
-                hdu = fetch_hdu_from_mongo(filename)
+                hdu = fetch_hdu_from_mongo(url)
                 image = accessors.FITSImage(hdu)
             else:
                 raise Exception("FITS file not available")

--- a/tkpweb/apps/dataset/tools/mongo.py
+++ b/tkpweb/apps/dataset/tools/mongo.py
@@ -1,0 +1,13 @@
+from tkpweb.settings import MONGODB
+from pymongo import Connection
+from gridfs import GridFS
+from contextlib import closing
+import pyfits
+
+def fetch_hdu_from_mongo(filename):
+    if MONGODB["enabled"]:
+        with closing(
+            Connection(host=MONGODB["host"], port=MONGODB["port"])
+        ) as mongo_connection:
+            gfs = GridFS(mongo_connection[MONGODB["database"]])
+            return pyfits.open(gfs.get_version(filename), mode="readonly")

--- a/tkpweb/apps/dataset/tools/plot.py
+++ b/tkpweb/apps/dataset/tools/plot.py
@@ -13,7 +13,6 @@ from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.patches import Rectangle
 from matplotlib.collections import PatchCollection
 from tkp.utility import accessors
-from .image import open_image
 import dbase
 
 from tkpweb.settings import MONGODB
@@ -106,7 +105,7 @@ class ThumbnailPlot(Plot):
                 hdu = fetch_hdu_from_mongo(filename)
                 image = accessors.FITSImage(hdu)
             else:
-                raise Exception("FITS file not available")
+                raise Exception("Image file not available")
         except Exception, e:
             # Unable to access file
             print e

--- a/tkpweb/apps/dataset/tools/plot.py
+++ b/tkpweb/apps/dataset/tools/plot.py
@@ -5,6 +5,7 @@ import datetime
 import time
 import numpy
 import aplpy
+import pyfits
 from scipy.stats import scoreatpercentile
 import matplotlib
 from matplotlib.figure import Figure

--- a/tkpweb/apps/dataset/tools/plot.py
+++ b/tkpweb/apps/dataset/tools/plot.py
@@ -1,3 +1,4 @@
+import os.path
 import StringIO
 import base64
 import datetime
@@ -72,8 +73,9 @@ class ImagePlot(Plot):
                 hdu = fetch_hdu_from_mongo(dbimage['url'])
             else:
                 raise Exception("FITS file not available")
-        except:
+        except Exception, e:
             # Unable to access file
+            print e
             return
 
         image = aplpy.FITSFigure(hdu, figure=self.figure, auto_refresh=False)

--- a/tkpweb/settings.py_template
+++ b/tkpweb/settings.py_template
@@ -181,7 +181,7 @@ MONETDB_LOGIN = {}
 
 # Configuration for MongoDB image store
 MONGODB = {
-    "enabled": True,
+    "enabled": False,
     "host": "pc-swinbank.science.uva.nl",
     "port": 27017,
     "database": "tkp"

--- a/tkpweb/settings.py_template
+++ b/tkpweb/settings.py_template
@@ -178,3 +178,11 @@ LOGGING = {
 
 LOGIN_URL = '/account/login/'
 MONETDB_LOGIN = {}
+
+# Configuration for MongoDB image store
+MONGODB = {
+    "enabled": True,
+    "host": "pc-swinbank.science.uva.nl",
+    "port": 27017,
+    "database": "tkp"
+}


### PR DESCRIPTION
This is the changes I've made to support pulling images for display from a MongoDB server rather than assuming they're available on the local filesystem. Note that the MongoDB support is optional: if it's not enabled in the settings, it should run fine on a system which doesn't have PyMongo installed.

This requires the changes I've recently merged to master in the `transientskp/tkp` repository.
